### PR TITLE
Add `progressbar` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn
 networkx>=2
 pandas
 bokeh
+progressbar


### PR DESCRIPTION
Package `progressbar` is used in several modules, but missing from `requirements.txt`. This causes an error if trying to use this package without having the dependency installed.

 Add it to requirements to ensure it will be present.

fix #2 